### PR TITLE
Fix GND URL for Bettina von Arnim

### DIFF
--- a/ELTeC-deu_metadata.tsv
+++ b/ELTeC-deu_metadata.tsv
@@ -5,7 +5,7 @@ ELTeC-deu	DEU007	DEU007	Stifter, Adalbert	Die Mappe meines Urgroßvaters	1805	18
 ELTeC-deu	DEU023	DEU023	Stifter, Adalbert	Feldblumen	1805	1868	M	http://d-nb.info/gnd/118618156	1841	1841	NA	1959	NA	NA	de	43934	NA	NA	short	high	T1
 ELTeC-deu	DEU017	DEU017	Stifter, Adalbert	Die Narrenburg	1805	1868	M	http://d-nb.info/gnd/118618156	1843	1843	NA	1959	NA	NA	de	41879	NA	NA	short	unspecified	T1
 ELTeC-deu	DEU021	DEU021	Lewald, Fanny	Jenny	1811	1889	F	http://d-nb.info/gnd/118572393	1843	1843	NA	1872	NA	NA	de	111473	NA	NA	long	low	T1
-ELTeC-deu	DEU022	DEU022	Arnim, Bettina von	Clemens Brentanos Frühlingskranz	1785	1859	F	http://d-nb.info/gnd/118572393	1844	1844	NA	1959	NA	NA	de	108645	NA	NA	long	high	T1
+ELTeC-deu	DEU022	DEU022	Arnim, Bettina von	Clemens Brentanos Frühlingskranz	1785	1859	F	http://d-nb.info/gnd/118504185	1844	1844	NA	1959	NA	NA	de	108645	NA	NA	long	high	T1
 ELTeC-deu	DEU001	DEU001	Willkomm, Ernst Adolf	Weisse Sclaven oder die Leiden des Volkes	1810	1886	M	http://d-nb.info/gnd/11739467X	1845	1845	NA	1845	NA	NA	de	322371	NA	NA	long	low	T1
 ELTeC-deu	DEU018	DEU018	Schopenhauer, Adele	Anna	1797	1849	F	http://d-nb.info/gnd/11880510X	1845	1845	NA	1845	NA	NA	de	105286	NA	NA	long	low	T1
 ELTeC-deu	DEU016	DEU016	Gerstäcker, Friedrich	Die Regulatoren in Arkansas. Aus dem Waldleben Amerikas	1816	1872	M	http://d-nb.info/gnd/118538810	1846	1846	NA	NA	NA	NA	de	183061	NA	NA	long	low	T1

--- a/level1/DEU022.xml
+++ b/level1/DEU022.xml
@@ -8,7 +8,7 @@
       <fileDesc>
          <titleStmt>
             <title>Clemens Brentanos Frühlingskranz : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118572393">Arnim, Bettina von (1785-1859)</author>
+            <author ref="http://d-nb.info/gnd/118504185">Arnim, Bettina von (1785-1859)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level2/DEU022.xml
+++ b/level2/DEU022.xml
@@ -6,7 +6,7 @@
 <fileDesc>
 <titleStmt>
 <title>Clemens Brentanos Frühlingskranz : ELTeC ausgabe</title>
-<author ref="http://d-nb.info/gnd/118572393">Arnim, Bettina von (1785-1859)</author>
+<author ref="http://d-nb.info/gnd/118504185">Arnim, Bettina von (1785-1859)</author>
 <respStmt>
 <resp>ELTeC conversion</resp>
 <name>Leonard Konle</name>

--- a/metadata/metadata.txt
+++ b/metadata/metadata.txt
@@ -20,7 +20,7 @@ DEU018,"Schopenhauer, Adele",Anna,foo,1845,T1,low,f,105286,long,1,1797,1849,http
 DEU019,"Stifter, Adalbert",Zwei Schwestern,foo,1846,T1,medium,m,58315,medium,1,1805,1868,http://d-nb.info/gnd/118618156
 DEU020,"Hahn-Hahn, Ida Gräfin von",Sibylle,foo,1846,T1,low,f,131733,long,1,1805,1880,http://d-nb.info/gnd/118544918
 DEU021,"Lewald, Fanny",Jenny,foo,1843,T1,low,f,111473,long,1,1811,1889,http://d-nb.info/gnd/118572393
-DEU022,"Arnim, Bettina von",Clemens Brentanos Frühlingskranz,foo,1844,T1,high,f,108645,long,1,1785,1859,http://d-nb.info/gnd/118572393
+DEU022,"Arnim, Bettina von",Clemens Brentanos Frühlingskranz,foo,1844,T1,high,f,108645,long,1,1785,1859,http://d-nb.info/gnd/118504185
 DEU023,"Stifter, Adalbert",Feldblumen,foo,1841,T1,high,m,43934,short,1,1805,1868,http://d-nb.info/gnd/118618156
 DEU024,"Gutzkow, Karl",Der Zauberer von Rom,foo,1858,T1,low,m,894081,long,1,1811,1878,http://d-nb.info/gnd/118543830
 DEU025,"Kürnberger, Ferdinand",Der Amerika-Müde,foo,1855,T1,low,m,81837,medium,1,1823,1879,http://d-nb.info/gnd/118567764


### PR DESCRIPTION
Th GND URL assigned to her was actually the one of Fanny Lewald.