### PR TITLE
Add Wikidata IDs to title and author ref attributes in level1 XML files

### DIFF
--- a/level1/DEU001.xml
+++ b/level1/DEU001.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Weisse Sclaven oder die Leiden des Volkes : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/11739467X">Willkomm, Ernst Adolf (1810-1886)</author>
+            <title ref="wikidata:Q111239632">Weisse Sclaven oder die Leiden des Volkes : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/11739467X wikidata:Q126789">Willkomm, Ernst Adolf (1810-1886)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU002.xml
+++ b/level1/DEU002.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Der Lehnhold : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/11865103X">Auerbach, Berthold (1812-1882)</author>
+            <title ref="wikidata:Q111239461">Der Lehnhold : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/11865103X wikidata:Q76715">Auerbach, Berthold (1812-1882)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU003.xml
+++ b/level1/DEU003.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Der Pedlar : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/116708859">Ruppius, Otto (1819-1864)</author>
+            <title ref="wikidata:Q111239466">Der Pedlar : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/116708859 wikidata:Q2040358">Ruppius, Otto (1819-1864)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU004.xml
+++ b/level1/DEU004.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Nürnberg. Zweiter Band : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118590901">Otto, Louise (1819-1895)</author>
+            <title ref="wikidata:Q111239600">Nürnberg. Zweiter Band : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118590901 wikidata:Q71507">Otto, Louise (1819-1895)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU005.xml
+++ b/level1/DEU005.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Der Sonnenwirt : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118778277">Kurz, Hermann (1813-1873)</author>
+            <title ref="wikidata:Q111239469">Der Sonnenwirt : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118778277 wikidata:Q95193">Kurz, Hermann (1813-1873)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU006.xml
+++ b/level1/DEU006.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Fragment eines Romans : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/117208612">Weerth, Georg (1822-1856)</author>
+            <title ref="wikidata:Q107000830">Fragment eines Romans : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/117208612 wikidata:Q78000">Weerth, Georg (1822-1856)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU007.xml
+++ b/level1/DEU007.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Die Mappe meines Urgroßvaters : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118618156">Stifter, Adalbert (1805-1868)</author>
+            <title ref="wikidata:Q111239487">Die Mappe meines Urgroßvaters : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118618156 wikidata:Q168542">Stifter, Adalbert (1805-1868)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU008.xml
+++ b/level1/DEU008.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Der Lautenbacher : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/11865103X">Auerbach, Berthold (1812-1882)</author>
+            <title ref="wikidata:Q111239460">Der Lautenbacher : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/11865103X wikidata:Q76715">Auerbach, Berthold (1812-1882)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU009.xml
+++ b/level1/DEU009.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Das Vermächtnis des Pedlars : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/116708859">Ruppius, Otto (1819-1864)</author>
+            <title ref="wikidata:Q111239454">Das Vermächtnis des Pedlars : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/116708859 wikidata:Q2040358">Ruppius, Otto (1819-1864)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU010.xml
+++ b/level1/DEU010.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Lydia : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118650769">Aston, Louise (1814-1871)</author>
+            <title ref="wikidata:Q111239590">Lydia : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118650769 wikidata:Q67888">Aston, Louise (1814-1871)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU011.xml
+++ b/level1/DEU011.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Soll und Haben : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118535455">Freytag, Gustav (1816-1895)</author>
+            <title ref="wikidata:Q2298931">Soll und Haben : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118535455 wikidata:Q58811">Freytag, Gustav (1816-1895)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU012.xml
+++ b/level1/DEU012.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Aus dem Leben einer Frau : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118650769">Aston, Louise (1814-1871)</author>
+            <title ref="wikidata:Q101323690">Aus dem Leben einer Frau : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118650769 wikidata:Q67888">Aston, Louise (1814-1871)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU013.xml
+++ b/level1/DEU013.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Barfüßele : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/11865103X">Auerbach, Berthold (1812-1882)</author>
+            <title ref="wikidata:Q808120">Barfüßele : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/11865103X wikidata:Q76715">Auerbach, Berthold (1812-1882)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU014.xml
+++ b/level1/DEU014.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Vittoria Accorombona : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/12989432X">Tieck, Ludwig (1773-1853)</author>
+            <title ref="wikidata:Q1403207">Vittoria Accorombona : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/12989432X wikidata:Q57239">Tieck, Ludwig (1773-1853)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU015.xml
+++ b/level1/DEU015.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Die Günderode : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118504185">Arnim, Bettina von (1785-1859)</author>
+            <title ref="wikidata:Q42190652">Die Günderode : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118504185 wikidata:Q57236">Arnim, Bettina von (1785-1859)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU016.xml
+++ b/level1/DEU016.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Die Regulatoren in Arkansas. Aus dem Waldleben Amerikas : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118538810">Gerstäcker, Friedrich (1816-1872)</author>
+            <title ref="wikidata:Q110879272">Die Regulatoren in Arkansas. Aus dem Waldleben Amerikas : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118538810 wikidata:Q77478">Gerstäcker, Friedrich (1816-1872)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU017.xml
+++ b/level1/DEU017.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Die Narrenburg : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118618156">Stifter, Adalbert (1805-1868)</author>
+            <title ref="wikidata:Q21328513">Die Narrenburg : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118618156 wikidata:Q168542">Stifter, Adalbert (1805-1868)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU018.xml
+++ b/level1/DEU018.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Anna : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/11880510X">Schopenhauer, Adele (1797-1849)</author>
+            <title ref="wikidata:Q111239424">Anna : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/11880510X wikidata:Q75090">Schopenhauer, Adele (1797-1849)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU019.xml
+++ b/level1/DEU019.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Zwei Schwestern : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118618156">Stifter, Adalbert (1805-1868)</author>
+            <title ref="wikidata:Q110757065">Zwei Schwestern : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118618156 wikidata:Q168542">Stifter, Adalbert (1805-1868)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU020.xml
+++ b/level1/DEU020.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Sibylle : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118544918">Hahn-Hahn, Ida Gräfin von
+            <title ref="wikidata:Q111239613">Sibylle : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118544918 wikidata:Q92101">Hahn-Hahn, Ida Gräfin von
                (1805-1880)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>

--- a/level1/DEU021.xml
+++ b/level1/DEU021.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Jenny : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118572393">Lewald, Fanny (1811-1889)</author>
+            <title ref="wikidata:Q111239566">Jenny : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118572393 wikidata:Q77318">Lewald, Fanny (1811-1889)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU022.xml
+++ b/level1/DEU022.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Clemens Brentanos Frühlingskranz : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118504185">Arnim, Bettina von (1785-1859)</author>
+            <title ref="wikidata:Q42187988">Clemens Brentanos Frühlingskranz : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118504185 wikidata:Q77318">Arnim, Bettina von (1785-1859)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU023.xml
+++ b/level1/DEU023.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Feldblumen : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118618156">Stifter, Adalbert (1805-1868)</author>
+            <title ref="wikidata:Q111239504">Feldblumen : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118618156 wikidata:Q168542">Stifter, Adalbert (1805-1868)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU025.xml
+++ b/level1/DEU025.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Der Amerika-Müde : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118567764">Kürnberger, Ferdinand (1823-1879)</author>
+            <title ref="wikidata:Q111239455">Der Amerika-Müde : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118567764 wikidata:Q669703">Kürnberger, Ferdinand (1823-1879)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU026.xml
+++ b/level1/DEU026.xml
@@ -7,8 +7,8 @@
  <teiHeader>
   <fileDesc>
    <titleStmt>
-    <title>Auch Einer 2 : ELTeC ausgabe</title>
-    <author ref="http://d-nb.info/gnd/11862721X">Vischer, Friedrich Theodor (1807-1887)</author>
+    <title ref="wikidata:Q111239427">Auch Einer 2 : ELTeC ausgabe</title>
+    <author ref="http://d-nb.info/gnd/11862721X wikidata:Q651">Vischer, Friedrich Theodor (1807-1887)</author>
     <respStmt>
      <resp>ELTeC conversion</resp>
      <name>Leonard Konle</name>

--- a/level1/DEU027.xml
+++ b/level1/DEU027.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Bozena : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118528661">Ebner-Eschenbach, Marie von
+            <title ref="wikidata:Q108667573">Bozena : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118528661 wikidata:Q93525">Ebner-Eschenbach, Marie von
                (1830-1916)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>

--- a/level1/DEU028.xml
+++ b/level1/DEU028.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Die letzte Reckenburgerin : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118692577">François, Louise von (1817-1893)</author>
+            <title ref="wikidata:Q111239484">Die letzte Reckenburgerin : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118692577 wikidata:Q84820">François, Louise von (1817-1893)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU029.xml
+++ b/level1/DEU029.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Alte Nester : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118597442">Raabe, Wilhelm (1831-1910)</author>
+            <title ref="wikidata:Q436036">Alte Nester : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118597442 wikidata:Q60647">Raabe, Wilhelm (1831-1910)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU030.xml
+++ b/level1/DEU030.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Die verlorene Handschrift : ELTeC ausgabe</title>
-          <author ref="http://d-nb.info/gnd/pnd:118535455">Freytag, Gustav (1816-1895)</author>
+            <title ref="wikidata:Q111239495">Die verlorene Handschrift : ELTeC ausgabe</title>
+          <author ref="http://d-nb.info/gnd/pnd:118535455 wikidata:Q58811">Freytag, Gustav (1816-1895)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU031.xml
+++ b/level1/DEU031.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Der Schüdderump : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118692577">Raabe, Wilhelm (1831-1910)</author>
+            <title ref="wikidata:Q1196819">Der Schüdderump : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118692577 wikidata:Q84820">Raabe, Wilhelm (1831-1910)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU032.xml
+++ b/level1/DEU032.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Jürg Jenatsch : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118581775">Meyer, Conrad Ferdinand
+            <title ref="wikidata:Q1411041">Jürg Jenatsch : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118581775 wikidata:Q123261">Meyer, Conrad Ferdinand
                (1825-1898)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>

--- a/level1/DEU033.xml
+++ b/level1/DEU033.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Die Geschichte meines Urgroßvaters : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118692577">François, Louise von (1817-1893)</author>
+            <title ref="wikidata:Q111239480">Die Geschichte meines Urgroßvaters : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118692577 wikidata:Q84820">François, Louise von (1817-1893)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU034.xml
+++ b/level1/DEU034.xml
@@ -7,8 +7,8 @@
  <teiHeader>
   <fileDesc>
    <titleStmt>
-    <title>Auch Einer 1 : ELTeC ausgabe</title>
-    <author ref="http://d-nb.info/gnd/11862721X">Vischer, Friedrich Theodor (1807-1887)</author>
+    <title ref="wikidata:Q111239426">Auch Einer 1 : ELTeC ausgabe</title>
+    <author ref="http://d-nb.info/gnd/11862721X wikidata:Q651">Vischer, Friedrich Theodor (1807-1887)</author>
     <respStmt>
      <resp>ELTeC conversion</resp>
      <name>Leonard Konle</name>

--- a/level1/DEU035.xml
+++ b/level1/DEU035.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Vor dem Sturm : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118534262">Fontane, Theodor (1819-1898)</author>
+            <title ref="wikidata:Q1273542">Vor dem Sturm : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118534262 wikidata:Q76632">Fontane, Theodor (1819-1898)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU036.xml
+++ b/level1/DEU036.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Der grüne Heinrich2 [Zweite Fassung] : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/11856109X">Keller, Gottfried (1819-1890)</author>
+            <title ref="wikidata:Q111239458">Der grüne Heinrich2 [Zweite Fassung] : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/11856109X wikidata:Q122370">Keller, Gottfried (1819-1890)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU037.xml
+++ b/level1/DEU037.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Das Heideprinzeßchen : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/1014122880">Marlitt, Eugenie (1825-1887)</author>
+            <title ref="wikidata:Q111238907">Das Heideprinzeßchen : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/1014122880 wikidata:Q62950">Marlitt, Eugenie (1825-1887)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU038.xml
+++ b/level1/DEU038.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Der Hungerpastor : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118597442">Raabe, Wilhelm (1831-1910)</author>
+            <title ref="wikidata:Q1194487">Der Hungerpastor : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118597442 wikidata:Q84820">Raabe, Wilhelm (1831-1910)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU039.xml
+++ b/level1/DEU039.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Problematische Naturen. Erste Abtheilung : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118616196">Spielhagen, Friedrich (1823-1911)</author>
+            <title ref="wikidata:Q111239603">Problematische Naturen. Erste Abtheilung : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118616196 wikidata:Q106603">Spielhagen, Friedrich (1823-1911)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU040.xml
+++ b/level1/DEU040.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Goldelse : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/1014122880">Marlitt, Eugenie (1825-1887)</author>
+            <title ref="wikidata:Q93955765">Goldelse : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/1014122880 wikidata:Q62950">Marlitt, Eugenie (1825-1887)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU041.xml
+++ b/level1/DEU041.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Das Geheimnis der alten Mamsell : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/1014122880">Marlitt, Eugenie (1825-1887)</author>
+            <title ref="wikidata:Q89518165">Das Geheimnis der alten Mamsell : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/1014122880 wikidata:Q62950">Marlitt, Eugenie (1825-1887)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU042.xml
+++ b/level1/DEU042.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Die Mandanenwaise : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118784412">Möllhausen, Balduin (1825-1905)</author>
+            <title ref="wikidata:Q111239486">Die Mandanenwaise : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118784412 wikidata:Q99917">Möllhausen, Balduin (1825-1905)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU043.xml
+++ b/level1/DEU043.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Hammer und Amboß : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118616196">Spielhagen, Friedrich (1823-1911)</author>
+            <title ref="wikidata:Q111239542">Hammer und Amboß : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118616196 wikidata:Q106603">Spielhagen, Friedrich (1823-1911)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU044.xml
+++ b/level1/DEU044.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Kampf um Rom : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118523392">Dahn, Felix (1834-1912)</author>
+            <title ref="wikidata:Q111239584">Kampf um Rom : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118523392 wikidata:Q61456">Dahn, Felix (1834-1912)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU045.xml
+++ b/level1/DEU045.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Witiko : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118618156">Stifter, Adalbert (1805-1868)</author>
+            <title ref="wikidata:Q1725092">Witiko : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118618156 wikidata:Q168542">Stifter, Adalbert (1805-1868)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU046.xml
+++ b/level1/DEU046.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Grete Minde : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118534262">Fontane, Theodor (1819-1898)</author>
+            <title ref="wikidata:Q179500">Grete Minde : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118534262 wikidata:Q76632">Fontane, Theodor (1819-1898)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU047.xml
+++ b/level1/DEU047.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Judith die Kluswirtin : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118692577">François, Louise von (1817-1893)</author>
+            <title ref="wikidata:Q111239573">Judith die Kluswirtin : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118692577 wikidata:Q84820">François, Louise von (1817-1893)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU049.xml
+++ b/level1/DEU049.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Die Leute aus dem Walde, ihre Sterne, Wege und Schicksale : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118692577">Raabe, Wilhelm (1831-1910)</author>
+            <title ref="wikidata:Q1214404">Die Leute aus dem Walde, ihre Sterne, Wege und Schicksale : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118692577 wikidata:Q84820">Raabe, Wilhelm (1831-1910)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU050.xml
+++ b/level1/DEU050.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Abu Telfan oder Die Heimkehr vom Mondgebirge : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118692577">Raabe, Wilhelm (1831-1910)</author>
+            <title ref="wikidata:Q335418">Abu Telfan oder Die Heimkehr vom Mondgebirge : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118692577 wikidata:Q84820">Raabe, Wilhelm (1831-1910)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU051.xml
+++ b/level1/DEU051.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Unterm Birnbaum : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118534262">Fontane, Theodor (1819-1898)</author>
+            <title ref="wikidata:Q938689">Unterm Birnbaum : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118534262 wikidata:Q76632">Fontane, Theodor (1819-1898)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU052.xml
+++ b/level1/DEU052.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Heidis Lehr- und Wanderjahre : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118616455">Spyri, Johanna (1827-1901)</author>
+            <title ref="wikidata:Q111239544">Heidis Lehr- und Wanderjahre : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118616455 wikidata:Q123053">Spyri, Johanna (1827-1901)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU053.xml
+++ b/level1/DEU053.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Graf Petöfy : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118534262">Fontane, Theodor (1819-1898)</author>
+            <title ref="wikidata:Q1541390">Graf Petöfy : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118534262 wikidata:Q76632">Fontane, Theodor (1819-1898)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU054.xml
+++ b/level1/DEU054.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Am Jenseits : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118818651">May, Karl (1842-1912)</author>
+            <title ref="wikidata:Q451338">Am Jenseits : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118818651 wikidata:Q22714">May, Karl (1842-1912)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU055.xml
+++ b/level1/DEU055.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Die gute Schule : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118505955">Bahr, Hermann (1836-1934)</author>
+            <title ref="wikidata:Q111239483">Die gute Schule : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118505955 wikidata:Q94034">Bahr, Hermann (1836-1934)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU056.xml
+++ b/level1/DEU056.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Adam Mensch : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118669923">Conradi, Hermann (1862-1890)</author>
+            <title ref="wikidata:Q108567895">Adam Mensch : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118669923 wikidata:Q88379">Conradi, Hermann (1862-1890)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU057.xml
+++ b/level1/DEU057.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Sibilla Dalmar : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/11852643X">Dohm, Hedwig (1831-1919)</author>
+            <title ref="wikidata:Q108632484">Sibilla Dalmar : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/11852643X wikidata:Q71491">Dohm, Hedwig (1831-1919)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU058.xml
+++ b/level1/DEU058.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Lotti, die Uhrmacherin : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118528661">Ebner-Eschenbach, Marie von
+            <title ref="wikidata:Q108668505">Lotti, die Uhrmacherin : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118528661 wikidata:Q93525">Ebner-Eschenbach, Marie von
                (1830-1916)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>

--- a/level1/DEU059.xml
+++ b/level1/DEU059.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Irrungen, Wirrungen : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118534262">Fontane, Theodor (1819-1898)</author>
+            <title ref="wikidata:Q669599">Irrungen, Wirrungen : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118534262 wikidata:Q76632">Fontane, Theodor (1819-1898)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU060.xml
+++ b/level1/DEU060.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Die Amazonenschlacht : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/117078719">Janitschek, Maria (1859-1927)</author>
+            <title ref="wikidata:Q111239479">Die Amazonenschlacht : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/117078719 wikidata:Q88216">Janitschek, Maria (1859-1927)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU061.xml
+++ b/level1/DEU061.xml
@@ -7,8 +7,8 @@
  <teiHeader>
   <fileDesc>
    <titleStmt>
-    <title>Größenwahn: ELTeC ausgabe</title>
-    <author ref="http://d-nb.info/gnd/118663909">Bleibtreu, Karl (1859-1928)</author>
+    <title ref="wikidata:Q105836056">Größenwahn: ELTeC ausgabe</title>
+    <author ref="http://d-nb.info/gnd/118663909 wikidata:Q95194">Bleibtreu, Karl (1859-1928)</author>
     <respStmt>
      <resp>ELTeC conversion</resp>
      <name>Leonard Konle</name>

--- a/level1/DEU062.xml
+++ b/level1/DEU062.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Der Büttnerbauer : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118803336">Polenz, Wilhelm von (1861-1903)</author>
+            <title ref="wikidata:Q111239456">Der Büttnerbauer : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118803336 wikidata:Q1555222">Polenz, Wilhelm von (1861-1903)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU063.xml
+++ b/level1/DEU063.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Wie Frauen werden : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/11852643X">Dohm, Hedwig (1831-1919)</author>
+            <title ref="wikidata:Q111239635">Wie Frauen werden : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/11852643X wikidata:Q71491">Dohm, Hedwig (1831-1919)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU064.xml
+++ b/level1/DEU064.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Jungfer Mutter : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/1014783895">Christen, Ada (1839-1901)</author>
+            <title ref="wikidata:Q111239576">Jungfer Mutter : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/1014783895 wikidata:Q85002">Christen, Ada (1839-1901)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU065.xml
+++ b/level1/DEU065.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Zum Zeitvertreib : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118616196">Spielhagen, Friedrich (1823-1911)</author>
+            <title ref="wikidata:Q111239639">Zum Zeitvertreib : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118616196 wikidata:Q106603">Spielhagen, Friedrich (1823-1911)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU066.xml
+++ b/level1/DEU066.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Der Stechlin : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118534262">Fontane, Theodor (1819-1898)</author>
+            <title ref="wikidata:Q1197130">Der Stechlin : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118534262 wikidata:Q76632">Fontane, Theodor (1819-1898)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU067.xml
+++ b/level1/DEU067.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Schloß Hubertus : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118537490">Ganghofer, Ludwig (1855-1920)</author>
+            <title ref="wikidata:Q86009476">Schloß Hubertus : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118537490 wikidata:Q77475">Ganghofer, Ludwig (1855-1920)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU068.xml
+++ b/level1/DEU068.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Conrad : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118616277">Spitteler, Carl (1845-1925)</author>
+            <title ref="wikidata:Q111239438">Conrad : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118616277 wikidata:Q226525">Spitteler, Carl (1845-1925)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU069.xml
+++ b/level1/DEU069.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Meister Timpe : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118715917">Kretzer, Max (1854-1941)</author>
+            <title ref="wikidata:Q111239597">Meister Timpe : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118715917 wikidata:Q108847">Kretzer, Max (1854-1941)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU070.xml
+++ b/level1/DEU070.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Schach von Wuthenow : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118534262">Fontane, Theodor (1819-1898)</author>
+            <title ref="wikidata:Q2229265">Schach von Wuthenow : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118534262 wikidata:Q76632">Fontane, Theodor (1819-1898)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU071.xml
+++ b/level1/DEU071.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Cécile : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118534262">Fontane, Theodor (1819-1898)</author>
+            <title ref="wikidata:Q1150085">Cécile : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118534262 wikidata:Q76632">Fontane, Theodor (1819-1898)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU072.xml
+++ b/level1/DEU072.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Im alten Eisen : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118692577">Raabe, Wilhelm (1831-1910)</author>
+            <title ref="wikidata:Q1474111">Im alten Eisen : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118692577 wikidata:Q84820">Raabe, Wilhelm (1831-1910)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU073.xml
+++ b/level1/DEU073.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Schicksale einer Seele : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/11852643X">Dohm, Hedwig (1831-1919)</author>
+            <title ref="wikidata:Q108632301">Schicksale einer Seele : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/11852643X wikidata:Q71491">Dohm, Hedwig (1831-1919)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU074.xml
+++ b/level1/DEU074.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Fanny Förster : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118662473">Boy-Ed, Ida (1852-1928)</author>
+            <title ref="wikidata:Q111239503">Fanny Förster : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118662473 wikidata:Q109471">Boy-Ed, Ida (1852-1928)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU075.xml
+++ b/level1/DEU075.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Ninive : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/117078719">Janitschek, Maria (1859-1927)</author>
+            <title ref="wikidata:Q111239598">Ninive : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/117078719 wikidata:Q88216">Janitschek, Maria (1859-1927)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU076.xml
+++ b/level1/DEU076.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Caspar Hauser : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/1014784077">Wassermann, Jakob (1873-1934)</author>
+            <title ref="wikidata:Q42187701">Caspar Hauser : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/1014784077 wikidata:Q60369">Wassermann, Jakob (1873-1934)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU077.xml
+++ b/level1/DEU077.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Ellen Olestjerne : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118600044">Reventlow, Franziska Gräfin zu
+            <title ref="wikidata:Q19193408">Ellen Olestjerne : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118600044 wikidata:Q71429">Reventlow, Franziska Gräfin zu
                (1871-1918)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>

--- a/level1/DEU078.xml
+++ b/level1/DEU078.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Der Taifun : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118531212">Essig, Hermann (1878-1918)</author>
+            <title ref="wikidata:Q111239472">Der Taifun : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118531212 wikidata:Q1611018">Essig, Hermann (1878-1918)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU079.xml
+++ b/level1/DEU079.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Die Aufzeichnungen des Malte Laurids Brigge : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118601024">Rilke, Rainer Maria (1875-1926)</author>
+            <title ref="wikidata:Q968544">Die Aufzeichnungen des Malte Laurids Brigge : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118601024 wikidata:Q76483">Rilke, Rainer Maria (1875-1926)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU080.xml
+++ b/level1/DEU080.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Dumala : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118561812">Keyserling, Eduard von (1855-1918)</author>
+            <title ref="wikidata:Q1264876">Dumala : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118561812 wikidata:Q77494">Keyserling, Eduard von (1855-1918)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU081.xml
+++ b/level1/DEU081.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Und Friede auf Erden! : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118818651">May, Karl (1842-1912)</author>
+            <title ref="wikidata:Q1743176">Und Friede auf Erden! : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118818651 wikidata:Q22714">May, Karl (1842-1912)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU082.xml
+++ b/level1/DEU082.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Lebenssucher : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/11867353X">Braun, Lily (1865-1916)</author>
+            <title ref="wikidata:Q111239585">Lebenssucher : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/11867353X wikidata:Q71372">Braun, Lily (1865-1916)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU083.xml
+++ b/level1/DEU083.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Paralyse : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118750607">Sack, Gustav (1885-1916)</author>
+            <title ref="wikidata:Q111239601">Paralyse : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118750607 wikidata:Q1556344">Sack, Gustav (1885-1916)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU084.xml
+++ b/level1/DEU084.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Ardistan und Dschinnistan II : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118818651">May, Karl (1842-1912)</author>
+            <title ref="wikidata:Q109390780">Ardistan und Dschinnistan II : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118818651 wikidata:Q22714">May, Karl (1842-1912)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU085.xml
+++ b/level1/DEU085.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Der Ochsenkrieg : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118537490">Ganghofer, Ludwig (1855-1920)</author>
+            <title ref="wikidata:Q23307587">Der Ochsenkrieg : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118537490 wikidata:Q77475">Ganghofer, Ludwig (1855-1920)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU086.xml
+++ b/level1/DEU086.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Himmlische und irdische Liebe : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/1014784034">Meysenbug, Malwida Freiin von
+            <title ref="wikidata:Q111239548">Himmlische und irdische Liebe : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/1014784034 wikidata:Q68795">Meysenbug, Malwida Freiin von
                (1861-1903)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>

--- a/level1/DEU087.xml
+++ b/level1/DEU087.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Briefe, die ihn nicht erreichten : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/104359080">Heyking, Elisabeth von (1861-1925)</author>
+            <title ref="wikidata:Q111239433">Briefe, die ihn nicht erreichten : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/104359080 wikidata:Q99578">Heyking, Elisabeth von (1861-1925)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU088.xml
+++ b/level1/DEU088.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Mathilde Möhring : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118534262">Fontane, Theodor (1819-1898)</author>
+            <title ref="wikidata:Q1634107">Mathilde Möhring : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118534262 wikidata:Q76632">Fontane, Theodor (1819-1898)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU089.xml
+++ b/level1/DEU089.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Die Abendburg : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/11863318X">Wille, Bruno (1860-1928)</author>
+            <title ref="wikidata:Q111239476">Die Abendburg : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/11863318X wikidata:Q97648">Wille, Bruno (1860-1928)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU090.xml
+++ b/level1/DEU090.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Von Paul zu Pedro : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118600044">Reventlow, Franziska Gräfin zu
+            <title ref="wikidata:Q111239626">Von Paul zu Pedro : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118600044 wikidata:Q71429">Reventlow, Franziska Gräfin zu
                (1871-1918)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>

--- a/level1/DEU091.xml
+++ b/level1/DEU091.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Casanovas Heimfahrt : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118609807">Schnitzler, Arthur (1862-1931)</author>
+            <title ref="wikidata:Q946444">Casanovas Heimfahrt : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118609807 wikidata:Q44331">Schnitzler, Arthur (1862-1931)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU092.xml
+++ b/level1/DEU092.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Jons und Erdme : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118619853">Sudermann, Hermann (1857-1928)</author>
+            <title ref="wikidata:Q107868849">Jons und Erdme : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118619853 wikidata:Q65448">Sudermann, Hermann (1857-1928)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU093.xml
+++ b/level1/DEU093.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Madam Bäurin : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118520555">Christ, Lena (1881-1920)</author>
+            <title ref="wikidata:Q111239591">Madam Bäurin : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118520555 wikidata:Q77925">Christ, Lena (1881-1920)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU094.xml
+++ b/level1/DEU094.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Der Weg ins Freie : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118609807">Schnitzler, Arthur (1862-1931)</author>
+            <title ref="wikidata:Q700479">Der Weg ins Freie : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118609807 wikidata:Q44331">Schnitzler, Arthur (1862-1931)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU095.xml
+++ b/level1/DEU095.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Flammetti : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118506234">Ball, Hugo (1886-1927)</author>
+            <title ref="wikidata:Q105624761">Flammetti : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118506234 wikidata:Q70989">Ball, Hugo (1886-1927)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU096.xml
+++ b/level1/DEU096.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Der Golem : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118582046">Meyrink, Gustav (1868-1932)</author>
+            <title ref="wikidata:Q673861">Der Golem : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118582046 wikidata:Q78511">Meyrink, Gustav (1868-1932)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU097.xml
+++ b/level1/DEU097.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Wellen : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118561812">Keyserling, Eduard von (1855-1918)</author>
+            <title ref="wikidata:Q2557617">Wellen : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118561812 wikidata:Q77494">Keyserling, Eduard von (1855-1918)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU098.xml
+++ b/level1/DEU098.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Herrn Dames Aufzeichnungen : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118600044">Reventlow, Franziska Gräfin zu
+            <title ref="wikidata:Q111239547">Herrn Dames Aufzeichnungen : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118600044 wikidata:Q71429">Reventlow, Franziska Gräfin zu
                (1871-1918)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>

--- a/level1/DEU099.xml
+++ b/level1/DEU099.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Mathias Bichler : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118520555">Christ, Lena (1881-1920)</author>
+            <title ref="wikidata:Q111239592">Mathias Bichler : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118520555 wikidata:Q77925">Christ, Lena (1881-1920)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>
                <name>Leonard Konle</name>

--- a/level1/DEU100.xml
+++ b/level1/DEU100.xml
@@ -7,8 +7,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Agave : ELTeC ausgabe</title>
-            <author ref="http://d-nb.info/gnd/118528661">Ebner-Eschenbach, Marie von
+            <title ref="wikidata:Q111239419">Agave : ELTeC ausgabe</title>
+            <author ref="http://d-nb.info/gnd/118528661 wikidata:Q93525">Ebner-Eschenbach, Marie von
                (1830-1916)</author>
             <respStmt>
                <resp>ELTeC conversion</resp>


### PR DESCRIPTION
Added wikidata:QXXXXX identifiers to the ref attribute of <title> and <author> elements in <titleStmt> for all 100 level1 texts. Author IDs added: 100 | Work IDs added: 100